### PR TITLE
The support form is now triggered by a link in the personal bar and not the badge on the right

### DIFF
--- a/src/intranett.policy/intranett/policy/browser/support.py
+++ b/src/intranett.policy/intranett/policy/browser/support.py
@@ -15,13 +15,14 @@ VIEWLET_TEXT = u"""
       dropboxID:   "20021871",
       url:         "https://jarn.zendesk.com",
       tabID:       "support",
-      tabColor:    "#444",
-      tabPosition: "Right"
+      hide_tab:       true,
     });
+    $('#supportLink').click(function() {
+       window.Zenbox.show()
+       });
   }
 </script>
 """
-
 
 class SupportViewlet(BrowserView):
     implements(IViewlet)

--- a/src/intranett.policy/intranett/policy/browser/templates/personal_bar.pt
+++ b/src/intranett.policy/intranett/policy/browser/templates/personal_bar.pt
@@ -19,6 +19,10 @@
                  tal:attributes="href string:${portal_url}/@@usergroup-userprefs"
                  i18n:translate="">Manage users</a>
             </li>
+            <li tal:condition="view/can_manage_users">
+              <a href="" id="supportLink"
+                 i18n:translate="">Support</a>
+            </li>
             <li>
               <a href=""
                  tal:attributes="href string:${portal_url}/logout"


### PR DESCRIPTION
This makes it work better on small screens, on low resolution the support badge can hover over important parts of the site.

Also makes it less prominent, so it is not so much in your face. 

One problem is that it has the same name has the support link in the footer. I suggest we rename one of them, either the bottom one to user manual or something similar or the support one to Email support. 
